### PR TITLE
ci(release): Remove 'Install prerequisites' step

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,13 +8,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Install prerequisites
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt update
-          sudo apt install gh
-
       - name: Checkout develop
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Install prerequisites
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt update
-          sudo apt install gh
-
       - name: Checkout develop
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Releae action is currently broken: https://github.com/deepcrawl/deepcrawl-test/actions/runs/15272413066/job/42950900779

Which prevents us from releasing our CLI with updated API URL.

According to the official gh cli docs, it comes pre-installed on gh-hosted runners so manual installation step is unnecessary: https://github.com/cli/cli?tab=readme-ov-file#github-actions